### PR TITLE
escaping constants

### DIFF
--- a/.github/actions/setup-wordpress/action.yml
+++ b/.github/actions/setup-wordpress/action.yml
@@ -88,8 +88,8 @@ runs:
         php wp-cli.phar config delete SECURE_AUTH_SALT
         php wp-cli.phar config delete LOGGED_IN_SALT
         php wp-cli.phar config delete NONCE_SALT
-        php wp-cli.phar config set WP_ENVIRONMENT_TYPE ${{ inputs.ENVIRONMENT }}
-        php wp-cli.phar config set "configProject" "require_once(ABSPATH . 'wp-config-project.php')" --raw --type="variable"
+        php wp-cli.phar config set WP_ENVIRONMENT_TYPE '${{ inputs.ENVIRONMENT }}'
+        php wp-cli.phar config set "configProject" "require_once(__DIR__ . \DIRECTORY_SEPARATOR . 'wp-config-project.php')" --raw --type="variable"
 
     - name: WordPress setup database
       shell: bash
@@ -138,7 +138,7 @@ runs:
     - name: Setup real database constants
       shell: bash
       run: |
-        php wp-cli.phar config set DB_NAME ${{ inputs.DB_NAME }}
-        php wp-cli.phar config set DB_USER ${{ inputs.DB_USER }}
-        php wp-cli.phar config set DB_PASSWORD ${{ inputs.DB_PASSWORD }}
-        php wp-cli.phar config set DB_HOST ${{ inputs.DB_HOST }}
+        php wp-cli.phar config set DB_NAME '${{ inputs.DB_NAME }}'
+        php wp-cli.phar config set DB_USER '${{ inputs.DB_USER }}'
+        php wp-cli.phar config set DB_PASSWORD '${{ inputs.DB_PASSWORD }}'
+        php wp-cli.phar config set DB_HOST '${{ inputs.DB_HOST }}'


### PR DESCRIPTION
### Fixed
- constans are now escaped
- `wp-config-project` is now not using ABSPATH const