### PR TITLE
Update PHP version defaults and fix action inconsistencies

### DIFF
--- a/.github/actions/lint/php-cs/action.yml
+++ b/.github/actions/lint/php-cs/action.yml
@@ -4,8 +4,9 @@ description: 'PHP check coding standards'
 inputs:
   PHP_VERSION:
     type: string
-    description: 'PHP version to use. Available options are 8.2, 8.3, etc.'
-    required: true
+    description: 'PHP version to use. Available options are 8.2, 8.3, 8.4, etc.'
+    required: false
+    default: "8.4"
   PROJECT_PATH:
     type: string
     description: 'Path to the project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>'

--- a/.github/actions/lint/php-stan/action.yml
+++ b/.github/actions/lint/php-stan/action.yml
@@ -4,8 +4,9 @@ description: 'PHP Static code analysis'
 inputs:
   PHP_VERSION:
     type: string
-    description: 'PHP version to use. Available options are 8.2, 8.3, etc.'
-    required: true
+    description: 'PHP version to use. Available options are 8.2, 8.3, 8.4, etc.'
+    required: false
+    default: "8.4"
   PROJECT_PATH:
     type: string
     description: 'Path to the project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>'

--- a/.github/actions/setup/theme-from-submodule-legacy/action.yml
+++ b/.github/actions/setup/theme-from-submodule-legacy/action.yml
@@ -25,7 +25,12 @@ inputs:
   USE_BUN:
     type: string
     description: "If true, bun is used instead of npm for running scripts"
-    default: false
+    default: "false"
+  PHP_VERSION:
+    type: string
+    description: "PHP version to use. Available options are 8.2, 8.3, 8.4, etc."
+    required: false
+    default: "8.4"
 
 runs:
   using: composite
@@ -58,6 +63,13 @@ runs:
       with:
         bun-version: latest
 
+    - name: PHP setup
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.PHP_VERSION }}
+        coverage: none
+        tools: composer:v2
+
     - name: Install dependencies
       uses: "ramsey/composer-install@v3"
       with:
@@ -69,7 +81,7 @@ runs:
       working-directory: ${{ inputs.PROJECT_PATH }}
       shell: bash
       run: |
-        npm ci --no-progress --no-dev --no-audit --ignore-scripts
+        npm ci --no-progress --omit=dev --no-audit --ignore-scripts
         npm run build
 
     - name: Install assets packages with bun

--- a/.github/actions/setup/theme-from-submodule/action.yml
+++ b/.github/actions/setup/theme-from-submodule/action.yml
@@ -25,7 +25,12 @@ inputs:
   USE_BUN:
     type: string
     description: "If true, bun is used instead of npm for running scripts"
-    default: false
+    default: "false"
+  PHP_VERSION:
+    type: string
+    description: "PHP version to use. Available options are 8.2, 8.3, 8.4, etc."
+    required: false
+    default: "8.4"
 
 runs:
   using: composite
@@ -58,6 +63,13 @@ runs:
       with:
         bun-version: latest
 
+    - name: PHP setup
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.PHP_VERSION }}
+        coverage: none
+        tools: composer:v2
+
     - name: Install dependencies
       uses: "ramsey/composer-install@v3"
       with:
@@ -69,7 +81,7 @@ runs:
       working-directory: ${{ inputs.PROJECT_PATH }}
       shell: bash
       run: |
-        npm ci --no-progress --no-dev --no-audit --ignore-scripts
+        npm ci --no-progress --omit=dev --no-audit --ignore-scripts
         npm run build
 
     - name: Install assets packages with bun

--- a/.github/actions/setup/theme-or-plugin-legacy/action.yml
+++ b/.github/actions/setup/theme-or-plugin-legacy/action.yml
@@ -13,11 +13,16 @@ inputs:
   USE_NODE:
     type: string
     description: "Set to default if you don't have node_modules folder in your project."
-    default: true
+    default: "true"
   USE_BUN:
     type: string
     description: "If true, bun is used instead of npm for running scripts"
-    default: false
+    default: "false"
+  PHP_VERSION:
+    type: string
+    description: "PHP version to use. Available options are 8.2, 8.3, 8.4, etc."
+    required: false
+    default: "8.4"
 
 runs:
   using: composite
@@ -43,6 +48,13 @@ runs:
       with:
         bun-version: latest
 
+    - name: PHP setup
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.PHP_VERSION }}
+        coverage: none
+        tools: composer:v2
+
     - name: Install dependencies
       uses: "ramsey/composer-install@v3"
       with:
@@ -54,7 +66,7 @@ runs:
       if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'false'
       shell: bash
       run: |
-        npm ci --no-progress --no-dev --no-audit --ignore-scripts
+        npm ci --no-progress --omit=dev --no-audit --ignore-scripts
         npm run build
 
     - name: Install assets packages with bun

--- a/.github/actions/setup/theme-or-plugin/action.yml
+++ b/.github/actions/setup/theme-or-plugin/action.yml
@@ -13,11 +13,16 @@ inputs:
   USE_NODE:
     type: string
     description: "Set to default if you don't have node_modules folder in your project."
-    default: true
+    default: "true"
   USE_BUN:
     type: string
     description: "If true, bun is used instead of npm for running scripts"
-    default: false
+    default: "false"
+  PHP_VERSION:
+    type: string
+    description: "PHP version to use. Available options are 8.2, 8.3, 8.4, etc."
+    required: false
+    default: "8.4"
 
 runs:
   using: composite
@@ -43,6 +48,13 @@ runs:
       with:
         bun-version: latest
 
+    - name: PHP setup
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.PHP_VERSION }}
+        coverage: none
+        tools: composer:v2
+
     - name: Install dependencies
       uses: "ramsey/composer-install@v3"
       with:
@@ -54,7 +66,7 @@ runs:
       if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'false'
       shell: bash
       run: |
-        npm ci --no-progress --no-dev --no-audit --ignore-scripts
+        npm ci --no-progress --omit=dev --no-audit --ignore-scripts
         npm run build
 
     - name: Install assets packages with bun

--- a/.github/actions/setup/wordpress-legacy/action.yml
+++ b/.github/actions/setup/wordpress-legacy/action.yml
@@ -4,8 +4,9 @@ description: 'Install WordPress with core and paid plugins'
 inputs:
   PHP_VERSION:
     type: string
-    description: "PHP version to use. Available options are 7.4, 8.0, etc."
-    required: true
+    description: "PHP version to use. Available options are 8.2, 8.3, 8.4, etc."
+    required: false
+    default: "8.4"
   ENVIRONMENT:
     type: string
     description: "Environment to deploy to and WP enviroment constant. Available options are staging, production, etc."

--- a/.github/actions/setup/wordpress-plugins/action.yml
+++ b/.github/actions/setup/wordpress-plugins/action.yml
@@ -4,8 +4,9 @@ description: 'Install WordPress with core for building plugins'
 inputs:
   PHP_VERSION:
     type: string
-    description: "PHP version to use. Available options are 7.4, 8.0, etc."
-    required: true
+    description: "PHP version to use. Available options are 8.2, 8.3, 8.4, etc."
+    required: false
+    default: "8.4"
   WORDPRESS_GH_ACTIONS:
     type: string
     description: "GitHub PAT token for the WordPress repository deployment"

--- a/.github/actions/setup/wordpress/action.yml
+++ b/.github/actions/setup/wordpress/action.yml
@@ -4,8 +4,9 @@ description: 'Install WordPress with core and paid plugins'
 inputs:
   PHP_VERSION:
     type: string
-    description: "PHP version to use. Available options are 7.4, 8.0, etc."
-    required: true
+    description: "PHP version to use. Available options are 8.2, 8.3, 8.4, etc."
+    required: false
+    default: "8.4"
   SETUP_FILE:
     type: string
     description: "Path to the setup file"

--- a/.github/actions/ssh/releases-cleanup/action.yml
+++ b/.github/actions/ssh/releases-cleanup/action.yml
@@ -11,15 +11,19 @@ inputs:
     description: 'Server SSH key'
     required: true
   SERVER_USER:
+    type: string
     description: 'Server used for deployment'
     required: true
   SERVER_HOST:
+    type: string
     description: 'Server host for deployment'
     required: true
   SERVER_ROOT:
+    type: string
     description: 'Server root directory for deployment'
     required: true
   SERVER_PORT:
+    type: string
     description: 'Server port for deployment'
     required: true
   RELEASES_FOLDER:
@@ -27,12 +31,15 @@ inputs:
     description: 'Releases folder name'
     default: 'releases'
   SSM_DEPLOY:
+    type: string
     description: 'Use AWS SSM tunnel for deployment'
     default: 'false'
   AWS_REGION:
+    type: string
     description: 'AWS region for SSM tunnel'
     default: ""
   AWS_ROLE:
+    type: string
     description: 'AWS role for SSM tunnel'
     default: ""
 
@@ -102,7 +109,7 @@ runs:
           counter=0
 
           if ((${#subdirectories[@]} == $index)); then
-            echo "Error: Releases ."
+            echo "Error: Nothing to clean up. The number of available releases matches the number you want to keep."
             exit 1
           fi
 

--- a/.github/actions/ssh/rollback/action.yml
+++ b/.github/actions/ssh/rollback/action.yml
@@ -11,15 +11,19 @@ inputs:
     description: 'Server SSH key'
     required: true
   SERVER_USER:
+    type: string
     description: 'Server used for deployment'
     required: true
   SERVER_HOST:
+    type: string
     description: 'Server host for deployment'
     required: true
   SERVER_ROOT:
+    type: string
     description: 'Server root directory for deployment'
     required: true
   SERVER_PORT:
+    type: string
     description: 'Server port for deployment'
     required: true
   RELEASES_FOLDER:
@@ -27,12 +31,15 @@ inputs:
     description: 'Releases folder name'
     default: 'releases'
   SSM_DEPLOY:
+    type: string
     description: 'Use AWS SSM tunnel for deployment'
     default: 'false'
   AWS_REGION:
+    type: string
     description: 'AWS region for SSM tunnel'
     default: ""
   AWS_ROLE:
+    type: string
     description: 'AWS role for SSM tunnel'
     default: ""
 

--- a/.github/actions/ssh/server-deploy-self-hosted-runner/action.yml
+++ b/.github/actions/ssh/server-deploy-self-hosted-runner/action.yml
@@ -7,15 +7,19 @@ inputs:
     description: 'Server SSH key'
     required: true
   SERVER_USER:
+    type: string
     description: 'Server used for deployment'
     required: true
   SERVER_HOST:
+    type: string
     description: 'Server host for deployment'
     required: true
   SERVER_ROOT:
+    type: string
     description: 'Server root directory for deployment'
     required: true
   SERVER_PORT:
+    type: string
     description: 'Server port for deployment'
     required: true
   RELEASES_TO_KEEP:

--- a/.github/actions/ssh/server-deploy/action.yml
+++ b/.github/actions/ssh/server-deploy/action.yml
@@ -7,15 +7,19 @@ inputs:
     description: 'Server SSH key'
     required: true
   SERVER_USER:
+    type: string
     description: 'Server used for deployment'
     required: true
   SERVER_HOST:
+    type: string
     description: 'Server host for deployment'
     required: true
   SERVER_ROOT:
+    type: string
     description: 'Server root directory for deployment'
     required: true
   SERVER_PORT:
+    type: string
     description: 'Server port for deployment'
     required: true
   RELEASES_TO_KEEP:
@@ -27,12 +31,15 @@ inputs:
     description: 'Releases folder name'
     default: 'releases'
   SSM_DEPLOY:
+    type: string
     description: 'Use AWS SSM tunnel for deployment'
     default: 'false'
   AWS_REGION:
+    type: string
     description: 'AWS region for SSM tunnel'
     default: ""
   AWS_ROLE:
+    type: string
     description: 'AWS role for SSM tunnel'
     default: ""
 

--- a/workflow-examples/ci/plugin-project.yml
+++ b/workflow-examples/ci/plugin-project.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.3"]
+        php: ["8.4"]
     steps:
       - name: PHP Static code analysis
         uses: infinum/eightshift-deploy-actions-public/.github/actions/lint/php-stan@main
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.3"]
+        php: ["8.4"]
     steps:
       - name: PHP check coding standards
         uses: infinum/eightshift-deploy-actions-public/.github/actions/lint/php-cs@main

--- a/workflow-examples/deploy/ssh/infinum-project-with-submodule-theme.yml
+++ b/workflow-examples/deploy/ssh/infinum-project-with-submodule-theme.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup WordPress
         uses: infinum/eightshift-deploy-actions-public/.github/actions/setup/wordpress@main
         with:
-          PHP_VERSION: "8.3"
+          PHP_VERSION: "8.4"
           WORDPRESS_GH_ACTIONS: ${{ secrets.WORDPRESS_GH_ACTIONS }}
 
       - name: Setup custom secrets as environment variables
@@ -123,7 +123,7 @@ jobs:
       name: Notify
       runs-on: ubuntu-latest
       environment: ${{ needs.context.outputs.environment }}
-      needs: [context, deploy]
+      needs: [context, build-and-push]
       steps:
         - name: Notify
           uses: infinum/eightshift-deploy-actions-public/.github/actions/slack-notification@main

--- a/workflow-examples/deploy/ssh/plugin-project-self-hosted-runner.yml
+++ b/workflow-examples/deploy/ssh/plugin-project-self-hosted-runner.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup WordPress
         uses: infinum/eightshift-deploy-actions-public/.github/actions/setup/wordpress@main
         with:
-          PHP_VERSION: "8.3"
+          PHP_VERSION: "8.4"
           WORDPRESS_GH_ACTIONS: ${{ secrets.WORDPRESS_GH_ACTIONS }}
 
       - name: Setup custom secrets as environment variables

--- a/workflow-examples/deploy/ssh/plugin-project.yml
+++ b/workflow-examples/deploy/ssh/plugin-project.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup WordPress
         uses: infinum/eightshift-deploy-actions-public/.github/actions/setup/wordpress@main
         with:
-          PHP_VERSION: "8.3"
+          PHP_VERSION: "8.4"
           WORDPRESS_GH_ACTIONS: ${{ secrets.WORDPRESS_GH_ACTIONS }}
 
       - name: Setup custom secrets as environment variables

--- a/workflow-examples/deploy/ssh/theme-project-self-hosted-runner.yml
+++ b/workflow-examples/deploy/ssh/theme-project-self-hosted-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup WordPress
         uses: infinum/eightshift-deploy-actions-public/.github/actions/setup/wordpress@main
         with:
-          PHP_VERSION: "8.3"
+          PHP_VERSION: "8.4"
           WORDPRESS_GH_ACTIONS: ${{ secrets.WORDPRESS_GH_ACTIONS }}
 
       - name: Setup custom secrets as environment variables

--- a/workflow-examples/deploy/ssh/theme-project.yml
+++ b/workflow-examples/deploy/ssh/theme-project.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup WordPress
         uses: infinum/eightshift-deploy-actions-public/.github/actions/setup/wordpress@main
         with:
-          PHP_VERSION: "8.3"
+          PHP_VERSION: "8.4"
           WORDPRESS_GH_ACTIONS: ${{ secrets.WORDPRESS_GH_ACTIONS }}
 
       - name: Setup custom secrets as environment variables


### PR DESCRIPTION
# Description

### Changed

- Updated `PHP_VERSION` input across all actions to be optional with a default of `8.4` (previously required with no default)
- Updated PHP setup actions (`theme-or-plugin`, `theme-or-plugin-legacy`, `theme-from-submodule`, `theme-from-submodule-legacy`) to explicitly set up PHP before running Composer — previously relied on whatever PHP the runner had installed
- Updated `USE_NODE` and `USE_BUN` defaults from YAML booleans to quoted strings (`"true"`/`"false"`) to match string comparisons in conditions
- Updated `npm ci --no-dev` to `npm ci --omit=dev` (valid flag) across all setup actions
- Updated PHP version in `ci/plugin-project.yml` example from `8.3` to `8.4`
- Updated missing `type: string` declarations on SSH action inputs (`releases-cleanup`, `server-deploy`, `server-deploy-self-hosted-runner`, `rollback`)
- Updated deploy workflow examples hardcoded PHP version from `8.3` to `8.4`

### Fixed

- Fixed truncated error message in `releases-cleanup` action (`"Error: Releases ."` → meaningful message)
- Fixed broken `notify` job dependency in `infinum-project-with-submodule-theme.yml` (`needs: deploy` → `needs: build-and-push`)
- Fixed double file extension `plugin-project-self-hosted-runner.yml.yml` → `.yml`

## QA Guide

1. Use any of the updated actions in a workflow without passing `PHP_VERSION` — it should default to `8.4`
2. Pass an explicit `PHP_VERSION: "8.2"` to override — should use that version
3. Trigger a deploy using the `infinum-project-with-submodule-theme.yml` example — the notify job should now run correctly after `build-and-push`
4. Trigger a `releases-cleanup` where releases count equals keep count — should now show a clear error message
5. Verify `npm ci` in setup actions installs only production dependencies

**Expected result:** All actions work with PHP 8.4 by default, per-project override via `PHP_VERSION` input, no broken job dependencies, no invalid npm flags.

# Screenshots / Videos

<!-- Add screenshots or screen recordings showing the changes in action. -->

# Productive ticket

N/A