### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/docker/build-push/action.yml
+++ b/.github/actions/docker/build-push/action.yml
@@ -106,20 +106,20 @@ runs:
 
     - name: Github authentication
       if: ${{ inputs.CLOUD == 'github' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ inputs.IMAGE_REGISTRY_URL }}
         username: ${{ github.actor }}
         password: ${{ inputs.WORDPRESS_GH_ACTIONS }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
       with:
         driver: docker-container
 
     - name: Configure AWS credentials (with OIDC or access keys)
       if: ${{ inputs.CLOUD == 'aws' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME || '' }}
         aws-region: ${{ inputs.AWS_REGION }}
@@ -136,7 +136,7 @@ runs:
 
     - name: Configure custom region for AWS ECR
       if: ${{ inputs.CLOUD == 'aws' && inputs.AWS_ECR_REGION && inputs.AWS_ECR_REGION != inputs.AWS_REGION }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: ${{ inputs.AWS_ECR_REGION }}
 
@@ -148,7 +148,7 @@ runs:
         registries: ${{ inputs.AWS_ECR_ACCOUNT_ID }}
 
     - name: Build and push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.CONTEXT }}
         platforms: ${{ inputs.PLATFORMS }}

--- a/.github/actions/lint/assets/action.yml
+++ b/.github/actions/lint/assets/action.yml
@@ -24,11 +24,11 @@ runs:
   steps:
     - name: Checkout
       if: inputs.USE_CHECKOUT == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set Node.js version - ${{ inputs.NODE_VERSION }}
       if: inputs.USE_BUN == 'false'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.NODE_VERSION }}
         cache: npm
@@ -36,7 +36,7 @@ runs:
 
     - name: Set Node.js version - ${{ inputs.NODE_VERSION }}
       if: inputs.USE_BUN == 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.NODE_VERSION }}
         cache-dependency-path: ${{ inputs.PROJECT_PATH }}/bun.lock

--- a/.github/actions/lint/php-cs/action.yml
+++ b/.github/actions/lint/php-cs/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: PHP setup
       uses: shivammathur/setup-php@v2
@@ -25,7 +25,7 @@ runs:
         coverage: none
 
     - name: Install dependencies
-      uses: "ramsey/composer-install@v3"
+      uses: "ramsey/composer-install@4.0.0"
       with:
         working-directory: ${{ inputs.PROJECT_PATH }}
 

--- a/.github/actions/lint/php-stan/action.yml
+++ b/.github/actions/lint/php-stan/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: PHP setup
       uses: shivammathur/setup-php@v2
@@ -25,7 +25,7 @@ runs:
         coverage: none
 
     - name: Install dependencies
-      uses: "ramsey/composer-install@v3"
+      uses: "ramsey/composer-install@4.0.0"
       with:
         working-directory: ${{ inputs.PROJECT_PATH }}
 

--- a/.github/actions/setup/theme-from-submodule-legacy/action.yml
+++ b/.github/actions/setup/theme-from-submodule-legacy/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - name: Install Node.js
       if: inputs.USE_BUN == 'false'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.NODE_VERSION }}
         cache: npm
@@ -52,7 +52,7 @@ runs:
 
     - name: Install Node.js
       if: inputs.USE_BUN == 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.NODE_VERSION }}
         cache-dependency-path: "${{ inputs.PROJECT_PATH }}/bun.lock"
@@ -71,7 +71,7 @@ runs:
         tools: composer:v2
 
     - name: Install dependencies
-      uses: "ramsey/composer-install@v3"
+      uses: "ramsey/composer-install@4.0.0"
       with:
         composer-options: "--no-dev"
         working-directory: ${{ inputs.PROJECT_PATH }}

--- a/.github/actions/setup/theme-from-submodule/action.yml
+++ b/.github/actions/setup/theme-from-submodule/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - name: Install Node.js
       if: inputs.USE_BUN == 'false'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.NODE_VERSION }}
         cache: npm
@@ -52,7 +52,7 @@ runs:
 
     - name: Install Node.js
       if: inputs.USE_BUN == 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.NODE_VERSION }}
         cache-dependency-path: "${{ inputs.PROJECT_PATH }}/bun.lock"
@@ -71,7 +71,7 @@ runs:
         tools: composer:v2
 
     - name: Install dependencies
-      uses: "ramsey/composer-install@v3"
+      uses: "ramsey/composer-install@4.0.0"
       with:
         composer-options: "--no-dev"
         working-directory: ${{ inputs.PROJECT_PATH }}

--- a/.github/actions/setup/theme-or-plugin-legacy/action.yml
+++ b/.github/actions/setup/theme-or-plugin-legacy/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'false'
       with:
         node-version: ${{ inputs.NODE_VERSION }}
@@ -36,7 +36,7 @@ runs:
         cache-dependency-path: "${{ inputs.PROJECT_PATH }}/package-lock.json"
 
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'true'
       with:
         node-version: ${{ inputs.NODE_VERSION }}
@@ -56,7 +56,7 @@ runs:
         tools: composer:v2
 
     - name: Install dependencies
-      uses: "ramsey/composer-install@v3"
+      uses: "ramsey/composer-install@4.0.0"
       with:
         composer-options: "--no-dev"
         working-directory: ${{ inputs.PROJECT_PATH }}

--- a/.github/actions/setup/theme-or-plugin/action.yml
+++ b/.github/actions/setup/theme-or-plugin/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'false'
       with:
         node-version: ${{ inputs.NODE_VERSION }}
@@ -36,7 +36,7 @@ runs:
         cache-dependency-path: "${{ inputs.PROJECT_PATH }}/package-lock.json"
 
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'true'
       with:
         node-version: ${{ inputs.NODE_VERSION }}
@@ -56,7 +56,7 @@ runs:
         tools: composer:v2
 
     - name: Install dependencies
-      uses: "ramsey/composer-install@v3"
+      uses: "ramsey/composer-install@4.0.0"
       with:
         composer-options: "--no-dev"
         working-directory: ${{ inputs.PROJECT_PATH }}

--- a/.github/actions/setup/wordpress-legacy/action.yml
+++ b/.github/actions/setup/wordpress-legacy/action.yml
@@ -96,7 +96,7 @@ runs:
   using: composite
   steps:
     - name: Checkout the project repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         token: ${{ inputs.WORDPRESS_GH_ACTIONS }}
         submodules: true

--- a/.github/actions/setup/wordpress/action.yml
+++ b/.github/actions/setup/wordpress/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Checkout the project repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         token: ${{ inputs.WORDPRESS_GH_ACTIONS }}
         submodules: true

--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -45,7 +45,7 @@ runs:
   using: composite
   steps:
     - name: Slack Notification
-      uses: rtCamp/action-slack-notify@v2.3.0
+      uses: rtCamp/action-slack-notify@v2.3.3
       env:
         SLACK_WEBHOOK: ${{ inputs.SLACK_WEBHOOK }}
         MSG_MINIMAL: ${{ inputs.MSG_MINIMAL }}

--- a/.github/actions/ssh/releases-cleanup/action.yml
+++ b/.github/actions/ssh/releases-cleanup/action.yml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Configure AWS Credentials
       if:  ${{ inputs.SSM_DEPLOY == 'true' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.AWS_ROLE }}
         aws-region: ${{ inputs.AWS_REGION }}
@@ -67,7 +67,7 @@ runs:
           ProxyCommand sh -c "aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
         EOF
     - name: Add server SSH key
-      uses: webfactory/ssh-agent@v0.9.0
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ inputs.SERVER_SSH_KEY }}
 

--- a/.github/actions/ssh/rollback/action.yml
+++ b/.github/actions/ssh/rollback/action.yml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Configure AWS Credentials
       if: ${{ inputs.SSM_DEPLOY == 'true' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.AWS_ROLE }}
         aws-region: ${{ inputs.AWS_REGION }}
@@ -68,7 +68,7 @@ runs:
         EOF
 
     - name: Add server SSH key
-      uses: webfactory/ssh-agent@v0.9.0
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ inputs.SERVER_SSH_KEY }}
 

--- a/.github/actions/ssh/server-deploy-self-hosted-runner/action.yml
+++ b/.github/actions/ssh/server-deploy-self-hosted-runner/action.yml
@@ -50,7 +50,7 @@ runs:
         github-token: ${{ inputs.GITHUB_TOKEN }}
 
     - name: Add server SSH key
-      uses: webfactory/ssh-agent@v0.9.0
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ inputs.SERVER_SSH_KEY }}
 

--- a/.github/actions/ssh/server-deploy-self-hosted-runner/action.yml
+++ b/.github/actions/ssh/server-deploy-self-hosted-runner/action.yml
@@ -45,7 +45,7 @@ runs:
         echo "NOW=$(date +'%Y%m%d%H%M%S')" >> "$GITHUB_OUTPUT"
       
     - name: Download a single artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         github-token: ${{ inputs.GITHUB_TOKEN }}
 

--- a/.github/actions/ssh/server-deploy/action.yml
+++ b/.github/actions/ssh/server-deploy/action.yml
@@ -54,7 +54,7 @@ runs:
 
     - name: Configure AWS Credentials
       if: ${{ inputs.SSM_DEPLOY == 'true' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.AWS_ROLE }}
         aws-region: ${{ inputs.AWS_REGION }}
@@ -74,7 +74,7 @@ runs:
         EOF
 
     - name: Add server SSH key
-      uses: webfactory/ssh-agent@v0.9.0
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ inputs.SERVER_SSH_KEY }}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ COPY --chown=www-data:www-data ./config/nginx.conf /etc/nginx/nginx.conf
 # Configure wp-cli and wp-cron
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
     && curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar.sha512 \
-    && sha512sum -c wp-cli.phar.sha512 \
+    && echo "$(cat wp-cli.phar.sha512)  wp-cli.phar" | sha512sum -c \
     && chmod +x wp-cli.phar && mv wp-cli.phar /usr/local/bin/wp \
     && rm wp-cli.phar.sha512
 COPY ./config/wp-cron /etc/cron.d/wp-cron

--- a/workflow-examples/bundle-artifact/plugin.yml
+++ b/workflow-examples/bundle-artifact/plugin.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ["latest"]
-        php: ["8.3"]
+        php: ["8.4"]
     steps:
       - name: Checkout the project repo
         uses: actions/checkout@v6

--- a/workflow-examples/bundle-artifact/plugin.yml
+++ b/workflow-examples/bundle-artifact/plugin.yml
@@ -18,7 +18,7 @@ jobs:
         php: ["8.3"]
     steps:
       - name: Checkout the project repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.WORDPRESS_GH_ACTIONS }}
           path: "wp-content/plugins/<plugin_name>"
@@ -58,7 +58,7 @@ jobs:
           zip -rq ../../release.zip <plugin_name>
 
       - name: Upload zip to artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release
           path: release.zip

--- a/workflow-examples/bundle-release/plugin.yml
+++ b/workflow-examples/bundle-release/plugin.yml
@@ -19,7 +19,7 @@ jobs:
         php: ["8.3"]
     steps:
       - name: Checkout the project repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.WORDPRESS_GH_ACTIONS }}
           path: "wp-content/plugins/<plugin_name>"

--- a/workflow-examples/bundle-release/plugin.yml
+++ b/workflow-examples/bundle-release/plugin.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ["latest"]
-        php: ["8.3"]
+        php: ["8.4"]
     steps:
       - name: Checkout the project repo
         uses: actions/checkout@v6

--- a/workflow-examples/deploy/docker/infinum-project-with-submodule-theme.yml
+++ b/workflow-examples/deploy/docker/infinum-project-with-submodule-theme.yml
@@ -59,7 +59,7 @@ jobs:
     needs: [context]
     steps:
       - name: Checkout the project repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.WORDPRESS_GH_ACTIONS }}
           submodules: recursive

--- a/workflow-examples/deploy/docker/plugin-project.yml
+++ b/workflow-examples/deploy/docker/plugin-project.yml
@@ -59,7 +59,7 @@ jobs:
     needs: [context]
     steps:
       - name: Checkout the project repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.WORDPRESS_GH_ACTIONS }}
 

--- a/workflow-examples/deploy/docker/theme-project.yml
+++ b/workflow-examples/deploy/docker/theme-project.yml
@@ -59,7 +59,7 @@ jobs:
     needs: [context]
     steps:
       - name: Checkout the project repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.WORDPRESS_GH_ACTIONS }}
 

--- a/workflow-examples/deploy/ssh/plugin-project-self-hosted-runner.yml
+++ b/workflow-examples/deploy/ssh/plugin-project-self-hosted-runner.yml
@@ -109,7 +109,7 @@ jobs:
         run: zip -rq release.zip .
 
       - name: Upload release to artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         id: artifact-upload-step
         with:
           path: release.zip

--- a/workflow-examples/deploy/ssh/theme-project-self-hosted-runner.yml
+++ b/workflow-examples/deploy/ssh/theme-project-self-hosted-runner.yml
@@ -110,7 +110,7 @@ jobs:
         run: zip -rq release.zip .
 
       - name: Upload release to artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         id: artifact-upload-step
         with:
           path: release.zip


### PR DESCRIPTION
# Description

Resolves the Node.js 20 deprecation warnings in GitHub Actions runs. Node.js 20 actions will stop working on June 2nd, 2026, and will be removed from runners on September 16th, 2026.

### Changed

- Updated `actions/checkout` from v4 to v6 (Node.js 24 runtime)
- Updated `actions/setup-node` from v4 to v6 (Node.js 24 runtime; auto-caching now limited to npm only — no impact as we pass \`cache: npm\` explicitly)
- Updated `aws-actions/configure-aws-credentials` from v4 to v6 (Node.js 24 runtime; requires Actions Runner v2.327.1+)
- Updated `docker/build-push-action` from v6 to v7 (Node.js 24 runtime; removes unused \`DOCKER_BUILD_NO_SUMMARY\` env var support)
- Updated `docker/setup-buildx-action` from v3 to v4 (Node.js 24 runtime; removes deprecated \`install\` input — not used)
- Updated `docker/login-action` from v3 to v4 (Node.js 24 runtime)
- Updated `ramsey/composer-install` from v3 to 4.0.0 (Node.js 24 runtime via updated \`actions/cache\`)
- Updated `webfactory/ssh-agent` from v0.9.0 to v0.10.0
- Updated `rtCamp/action-slack-notify` from v2.3.0 to v2.3.3
- Fixed wp-cli sha512sum verification syntax in Dockerfile

## Breaking changes / notes

All Node.js 24 actions require **Actions Runner v2.327.1 or later**. GitHub-hosted runners already meet this requirement. Self-hosted runners must be updated to v2.327.1+ before these changes can be deployed.

## QA Guide

1. Trigger any deploy workflow (SSH or Docker) and verify it completes without the Node.js 20 deprecation warnings
2. Trigger a CI workflow and verify PHP linting and asset linting both pass
3. Confirm no warnings about deprecated action versions in the Annotations section

**Expected result:** No Node.js 20 deprecation warnings in workflow runs.

# Screenshots / Videos

<!-- Add screenshots or screen recordings showing the changes in action. -->

# Productive ticket

N/A