### PR TITLE
Add internal deploy-ecs-task-definition reusable workflow

### DIFF
--- a/.github/workflows/deploy-ecs-task-definition.yml
+++ b/.github/workflows/deploy-ecs-task-definition.yml
@@ -3,44 +3,44 @@ name: Deploy to ECS service
 on:
   workflow_call:
     inputs:
-      image_uri:
+      IMAGE_URI:
         description: "Docker image URI to deploy (eg. 123456789.dkr.ecr.eu-west-1.amazonaws.com/my-app:abc1234)"
         required: true
         type: string
-      environment:
+      ENVIRONMENT:
         description: "GitHub Actions environment (eg. staging or production)"
         required: true
         type: string
-      git_ref:
+      GIT_REF:
         description: "Commit hash or branch name to checkout"
         required: true
         type: string
-      timeout_minutes:
+      TIMEOUT_MINUTES:
         description: "Job timeout in minutes"
         required: false
         type: number
         default: 30
-      task_def_path:
+      TASK_DEF_PATH:
         description: "Path to the ECS task definition JSON file (eg. .aws/ecs/task-definition-app-staging.json)"
         required: true
         type: string
-      aws_region:
+      AWS_REGION:
         description: "AWS region where ECS cluster is deployed"
         required: true
         type: string
-      container_name:
+      CONTAINER_NAME:
         description: "Name of the container in the task definition to update"
         required: true
         type: string
-      ecs_service:
+      ECS_SERVICE:
         description: "Name of the ECS service to update"
         required: true
         type: string
-      ecs_cluster:
+      ECS_CLUSTER:
         description: "Name of the ECS cluster"
         required: true
         type: string
-      aws_role_to_assume:
+      AWS_ROLE_TO_ASSUME:
         description: "ARN of the AWS IAM role to assume via OIDC"
         required: false
         type: string
@@ -53,34 +53,34 @@ jobs:
   deploy:
     name: Deploy to ECS service
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    timeout-minutes: ${{ inputs.timeout_minutes }}
+    environment: ${{ inputs.ENVIRONMENT }}
+    timeout-minutes: ${{ inputs.TIMEOUT_MINUTES }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.git_ref }}
+          ref: ${{ inputs.GIT_REF }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ inputs.aws_region }}
-          role-to-assume: ${{ inputs.aws_role_to_assume }}
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}
 
       - name: Update image in task definition
         id: render-task-def
         uses: aws-actions/amazon-ecs-render-task-definition@v1.8.4
         with:
-          task-definition: ${{ inputs.task_def_path }}
-          container-name: ${{ inputs.container_name }}
-          image: ${{ inputs.image_uri }}
+          task-definition: ${{ inputs.TASK_DEF_PATH }}
+          container-name: ${{ inputs.CONTAINER_NAME }}
+          image: ${{ inputs.IMAGE_URI }}
 
       - name: Deploy task definition to ECS
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: ${{ steps.render-task-def.outputs.task-definition }}
-          service: ${{ inputs.ecs_service }}
-          cluster: ${{ inputs.ecs_cluster }}
+          service: ${{ inputs.ECS_SERVICE }}
+          cluster: ${{ inputs.ECS_CLUSTER }}
           wait-for-service-stability: true

--- a/.github/workflows/deploy-ecs-task-definition.yml
+++ b/.github/workflows/deploy-ecs-task-definition.yml
@@ -1,0 +1,86 @@
+name: Deploy to ECS service
+
+on:
+  workflow_call:
+    inputs:
+      image_uri:
+        description: "Docker image URI to deploy (eg. 123456789.dkr.ecr.eu-west-1.amazonaws.com/my-app:abc1234)"
+        required: true
+        type: string
+      environment:
+        description: "GitHub Actions environment (eg. staging or production)"
+        required: true
+        type: string
+      git_ref:
+        description: "Commit hash or branch name to checkout"
+        required: true
+        type: string
+      timeout_minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 30
+      task_def_path:
+        description: "Path to the ECS task definition JSON file (eg. .aws/ecs/task-definition-app-staging.json)"
+        required: true
+        type: string
+      aws_region:
+        description: "AWS region where ECS cluster is deployed"
+        required: true
+        type: string
+      container_name:
+        description: "Name of the container in the task definition to update"
+        required: true
+        type: string
+      ecs_service:
+        description: "Name of the ECS service to update"
+        required: true
+        type: string
+      ecs_cluster:
+        description: "Name of the ECS cluster"
+        required: true
+        type: string
+      aws_role_to_assume:
+        description: "ARN of the AWS IAM role to assume via OIDC"
+        required: false
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to ECS service
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.git_ref }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ inputs.aws_region }}
+          role-to-assume: ${{ inputs.aws_role_to_assume }}
+
+      - name: Update image in task definition
+        id: render-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1.8.4
+        with:
+          task-definition: ${{ inputs.task_def_path }}
+          container-name: ${{ inputs.container_name }}
+          image: ${{ inputs.image_uri }}
+
+      - name: Deploy task definition to ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-task-def.outputs.task-definition }}
+          service: ${{ inputs.ecs_service }}
+          cluster: ${{ inputs.ecs_cluster }}
+          wait-for-service-stability: true

--- a/.github/workflows/rollback-ecs-service.yml
+++ b/.github/workflows/rollback-ecs-service.yml
@@ -1,0 +1,143 @@
+name: Rollback ECS service
+
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        description: "AWS region where ECS cluster is deployed"
+        required: true
+        type: string
+      AWS_ROLE_TO_ASSUME:
+        description: "ARN of the AWS IAM role to assume via OIDC"
+        required: true
+        type: string
+      ECS_CLUSTER:
+        description: "Name of the ECS cluster"
+        required: true
+        type: string
+      ECS_SERVICE:
+        description: "Name of the ECS service to roll back"
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  rollback:
+    name: Rollback ECS service
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-session-name: "github-actions-ecs-rollback"
+
+      - name: Print rollback context
+        env:
+          AWS_REGION: ${{ inputs.AWS_REGION }}
+          ECS_CLUSTER: ${{ inputs.ECS_CLUSTER }}
+          ECS_SERVICE: ${{ inputs.ECS_SERVICE }}
+        run: |
+          echo "STARTING AUTOMATIC ROLLBACK"
+          echo "Region:  $AWS_REGION"
+          echo "Cluster: $ECS_CLUSTER"
+          echo "Service: $ECS_SERVICE"
+
+      - name: Get current task definition
+        id: get-current
+        shell: bash
+        env:
+          CLUSTER: ${{ inputs.ECS_CLUSTER }}
+          SERVICE: ${{ inputs.ECS_SERVICE }}
+          REGION: ${{ inputs.AWS_REGION }}
+        run: |
+          set -e
+
+          CURRENT_ARN=$(aws ecs describe-services \
+            --cluster "$CLUSTER" \
+            --service "$SERVICE" \
+            --region "$REGION" \
+            --query 'services[0].taskDefinition' \
+            --output text)
+
+          if [ "$CURRENT_ARN" == "None" ] || [ -z "$CURRENT_ARN" ]; then
+            echo "Error: Service '$SERVICE' not found in cluster '$CLUSTER' or has no active task definition."
+            exit 1
+          fi
+
+          echo "Currently running task definition: $CURRENT_ARN"
+          echo "current_arn=$CURRENT_ARN" >> "$GITHUB_OUTPUT"
+
+      - name: Determine previous task definition
+        id: get-previous
+        shell: bash
+        env:
+          REGION: ${{ inputs.AWS_REGION }}
+          CURRENT_ARN: ${{ steps.get-current.outputs.current_arn }}
+        run: |
+          set -e
+
+          FAMILY=$(echo "$CURRENT_ARN" | cut -d '/' -f 2 | cut -d ':' -f 1)
+          echo "Detected family: $FAMILY"
+
+          ALL_REVISIONS=$(aws ecs list-task-definitions \
+            --family-prefix "$FAMILY" \
+            --status ACTIVE \
+            --sort DESC \
+            --region "$REGION" \
+            --query 'taskDefinitionArns' \
+            --output text)
+
+          TARGET_ARN=$(echo "$ALL_REVISIONS" | tr '\t' '\n' | grep -F -A 1 "$CURRENT_ARN" | tail -n 1)
+
+          if [[ "$TARGET_ARN" == "$CURRENT_ARN" ]] || [[ -z "$TARGET_ARN" ]]; then
+            echo "Error: No previous revision found. You might be on the oldest one available."
+            exit 1
+          fi
+
+          echo "Previous ACTIVE revision detected: $TARGET_ARN"
+          echo "target_arn=$TARGET_ARN" >> "$GITHUB_OUTPUT"
+
+      - name: Update ECS service to previous revision
+        shell: bash
+        env:
+          CLUSTER: ${{ inputs.ECS_CLUSTER }}
+          SERVICE: ${{ inputs.ECS_SERVICE }}
+          REGION: ${{ inputs.AWS_REGION }}
+          TARGET_ARN: ${{ steps.get-previous.outputs.target_arn }}
+        run: |
+          set -e
+
+          echo "Rolling back service '$SERVICE' on cluster '$CLUSTER' to: $TARGET_ARN"
+
+          aws ecs update-service \
+            --cluster "$CLUSTER" \
+            --service "$SERVICE" \
+            --task-definition "$TARGET_ARN" \
+            --region "$REGION" \
+            --force-new-deployment > /dev/null
+
+      - name: Wait for service stabilization
+        shell: bash
+        env:
+          CLUSTER: ${{ inputs.ECS_CLUSTER }}
+          SERVICE: ${{ inputs.ECS_SERVICE }}
+          REGION: ${{ inputs.AWS_REGION }}
+        run: |
+          set -e
+
+          echo "Waiting for service stabilization..."
+
+          aws ecs wait services-stable \
+            --cluster "$CLUSTER" \
+            --service "$SERVICE" \
+            --region "$REGION"
+
+          echo "Rollback successful!"

--- a/workflow-examples/deploy/docker/infinum-project-with-submodule-theme.yml
+++ b/workflow-examples/deploy/docker/infinum-project-with-submodule-theme.yml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
     outputs:
-      aws_region: ${{ steps.get.outputs.aws_region }}
+      AWS_REGION: ${{ steps.get.outputs.aws_region }}
       aws_ecr_uri: ${{ steps.get.outputs.aws_ecr_uri }}
       aws_ecr_region: ${{ steps.get.outputs.aws_ecr_region }}
       aws_ecr_account_id: ${{ steps.get.outputs.aws_ecr_account_id }}
       aws_ecs_cluster: ${{ steps.get.outputs.aws_ecs_cluster }}
       aws_ecs_deploy_role: ${{ steps.get.outputs.aws_ecs_deploy_role }}
       git_revision: ${{ github.sha }}
-      environment: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
+      ENVIRONMENT: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
     steps:
       - id: get
         run: |
@@ -122,15 +122,15 @@ jobs:
     needs: [context, build-and-push]
     uses: infinum/eightshift-deploy-actions-public/.github/workflows/deploy-ecs-task-definition.yml@main
     with:
-      git_ref: ${{ github.ref }}
-      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}
-      environment: ${{ needs.context.outputs.environment }}
-      aws_region: ${{ needs.context.outputs.aws_region }}
-      ecs_cluster: ${{ needs.context.outputs.aws_ecs_cluster }}
-      ecs_service: <ecs_service>
-      task_def_path: ".aws/ecs/task-definition-app-${{ needs.context.outputs.environment }}.json"
-      container_name: <container_name>
-      aws_role_to_assume: ${{ needs.context.outputs.aws_ecs_deploy_role }}
+      GIT_REF: ${{ github.ref }}
+      IMAGE_URI: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}
+      ENVIRONMENT: ${{ needs.context.outputs.environment }}
+      AWS_REGION: ${{ needs.context.outputs.aws_region }}
+      ECS_CLUSTER: ${{ needs.context.outputs.aws_ecs_cluster }}
+      ECS_SERVICE: <ecs_service>
+      TASK_DEF_PATH: ".aws/ecs/task-definition-app-${{ needs.context.outputs.environment }}.json"
+      CONTAINER_NAME: <container_name>
+      AWS_ROLE_TO_ASSUME: ${{ needs.context.outputs.aws_ecs_deploy_role }}
 
   notify:
     name: Notify

--- a/workflow-examples/deploy/docker/infinum-project-with-submodule-theme.yml
+++ b/workflow-examples/deploy/docker/infinum-project-with-submodule-theme.yml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
     outputs:
-      AWS_REGION: ${{ steps.get.outputs.aws_region }}
+      aws_region: ${{ steps.get.outputs.aws_region }}
       aws_ecr_uri: ${{ steps.get.outputs.aws_ecr_uri }}
       aws_ecr_region: ${{ steps.get.outputs.aws_ecr_region }}
       aws_ecr_account_id: ${{ steps.get.outputs.aws_ecr_account_id }}
       aws_ecs_cluster: ${{ steps.get.outputs.aws_ecs_cluster }}
       aws_ecs_deploy_role: ${{ steps.get.outputs.aws_ecs_deploy_role }}
       git_revision: ${{ github.sha }}
-      ENVIRONMENT: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
+      environment: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
     steps:
       - id: get
         run: |

--- a/workflow-examples/deploy/docker/infinum-project-with-submodule-theme.yml
+++ b/workflow-examples/deploy/docker/infinum-project-with-submodule-theme.yml
@@ -120,7 +120,7 @@ jobs:
   deploy:
     name: Deploy
     needs: [context, build-and-push]
-    uses: infinum/devops-pipelines/.github/workflows/deploy-ecs-task-definition.yml@v3.0.0
+    uses: infinum/eightshift-deploy-actions-public/.github/workflows/deploy-ecs-task-definition.yml@main
     with:
       git_ref: ${{ github.ref }}
       image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}

--- a/workflow-examples/deploy/docker/plugin-project.yml
+++ b/workflow-examples/deploy/docker/plugin-project.yml
@@ -111,7 +111,7 @@ jobs:
   deploy:
     name: Deploy
     needs: [context, build-and-push]
-    uses: infinum/devops-pipelines/.github/workflows/deploy-ecs-task-definition.yml@v3.0.0
+    uses: infinum/eightshift-deploy-actions-public/.github/workflows/deploy-ecs-task-definition.yml@main
     with:
       git_ref: ${{ github.ref }}
       image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}

--- a/workflow-examples/deploy/docker/plugin-project.yml
+++ b/workflow-examples/deploy/docker/plugin-project.yml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
     outputs:
-      aws_region: ${{ steps.get.outputs.aws_region }}
+      AWS_REGION: ${{ steps.get.outputs.aws_region }}
       aws_ecr_uri: ${{ steps.get.outputs.aws_ecr_uri }}
       aws_ecr_region: ${{ steps.get.outputs.aws_ecr_region }}
       aws_ecr_account_id: ${{ steps.get.outputs.aws_ecr_account_id }}
       aws_ecs_cluster: ${{ steps.get.outputs.aws_ecs_cluster }}
       aws_ecs_deploy_role: ${{ steps.get.outputs.aws_ecs_deploy_role }}
       git_revision: ${{ github.sha }}
-      environment: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
+      ENVIRONMENT: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
     steps:
       - id: get
         run: |
@@ -113,15 +113,15 @@ jobs:
     needs: [context, build-and-push]
     uses: infinum/eightshift-deploy-actions-public/.github/workflows/deploy-ecs-task-definition.yml@main
     with:
-      git_ref: ${{ github.ref }}
-      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}
-      environment: ${{ needs.context.outputs.environment }}
-      aws_region: ${{ needs.context.outputs.aws_region }}
-      ecs_cluster: ${{ needs.context.outputs.aws_ecs_cluster }}
-      ecs_service: <ecs_service>
-      task_def_path: ".aws/ecs/task-definition-app-${{ needs.context.outputs.environment }}.json"
-      container_name: <container_name>
-      aws_role_to_assume: ${{ needs.context.outputs.aws_ecs_deploy_role }}
+      GIT_REF: ${{ github.ref }}
+      IMAGE_URI: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}
+      ENVIRONMENT: ${{ needs.context.outputs.environment }}
+      AWS_REGION: ${{ needs.context.outputs.aws_region }}
+      ECS_CLUSTER: ${{ needs.context.outputs.aws_ecs_cluster }}
+      ECS_SERVICE: <ecs_service>
+      TASK_DEF_PATH: ".aws/ecs/task-definition-app-${{ needs.context.outputs.environment }}.json"
+      CONTAINER_NAME: <container_name>
+      AWS_ROLE_TO_ASSUME: ${{ needs.context.outputs.aws_ecs_deploy_role }}
 
   notify:
     name: Notify

--- a/workflow-examples/deploy/docker/plugin-project.yml
+++ b/workflow-examples/deploy/docker/plugin-project.yml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
     outputs:
-      AWS_REGION: ${{ steps.get.outputs.aws_region }}
+      aws_region: ${{ steps.get.outputs.aws_region }}
       aws_ecr_uri: ${{ steps.get.outputs.aws_ecr_uri }}
       aws_ecr_region: ${{ steps.get.outputs.aws_ecr_region }}
       aws_ecr_account_id: ${{ steps.get.outputs.aws_ecr_account_id }}
       aws_ecs_cluster: ${{ steps.get.outputs.aws_ecs_cluster }}
       aws_ecs_deploy_role: ${{ steps.get.outputs.aws_ecs_deploy_role }}
       git_revision: ${{ github.sha }}
-      ENVIRONMENT: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
+      environment: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
     steps:
       - id: get
         run: |

--- a/workflow-examples/deploy/docker/theme-project.yml
+++ b/workflow-examples/deploy/docker/theme-project.yml
@@ -116,7 +116,7 @@ jobs:
   deploy:
     name: Deploy
     needs: [context, build-and-push]
-    uses: infinum/devops-pipelines/.github/workflows/deploy-ecs-task-definition.yml@v3.0.0
+    uses: infinum/eightshift-deploy-actions-public/.github/workflows/deploy-ecs-task-definition.yml@main
     with:
       git_ref: ${{ github.ref }}
       image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}

--- a/workflow-examples/deploy/docker/theme-project.yml
+++ b/workflow-examples/deploy/docker/theme-project.yml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
     outputs:
-      AWS_REGION: ${{ steps.get.outputs.aws_region }}
+      aws_region: ${{ steps.get.outputs.aws_region }}
       aws_ecr_uri: ${{ steps.get.outputs.aws_ecr_uri }}
       aws_ecr_region: ${{ steps.get.outputs.aws_ecr_region }}
       aws_ecr_account_id: ${{ steps.get.outputs.aws_ecr_account_id }}
       aws_ecs_cluster: ${{ steps.get.outputs.aws_ecs_cluster }}
       aws_ecs_deploy_role: ${{ steps.get.outputs.aws_ecs_deploy_role }}
       git_revision: ${{ github.sha }}
-      ENVIRONMENT: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
+      environment: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
     steps:
       - id: get
         run: |

--- a/workflow-examples/deploy/docker/theme-project.yml
+++ b/workflow-examples/deploy/docker/theme-project.yml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
     outputs:
-      aws_region: ${{ steps.get.outputs.aws_region }}
+      AWS_REGION: ${{ steps.get.outputs.aws_region }}
       aws_ecr_uri: ${{ steps.get.outputs.aws_ecr_uri }}
       aws_ecr_region: ${{ steps.get.outputs.aws_ecr_region }}
       aws_ecr_account_id: ${{ steps.get.outputs.aws_ecr_account_id }}
       aws_ecs_cluster: ${{ steps.get.outputs.aws_ecs_cluster }}
       aws_ecs_deploy_role: ${{ steps.get.outputs.aws_ecs_deploy_role }}
       git_revision: ${{ github.sha }}
-      environment: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
+      ENVIRONMENT: ${{ inputs.ENVIRONMENT != '' && inputs.ENVIRONMENT || 'staging' }}
     steps:
       - id: get
         run: |
@@ -118,15 +118,15 @@ jobs:
     needs: [context, build-and-push]
     uses: infinum/eightshift-deploy-actions-public/.github/workflows/deploy-ecs-task-definition.yml@main
     with:
-      git_ref: ${{ github.ref }}
-      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}
-      environment: ${{ needs.context.outputs.environment }}
-      aws_region: ${{ needs.context.outputs.aws_region }}
-      ecs_cluster: ${{ needs.context.outputs.aws_ecs_cluster }}
-      ecs_service: <ecs_service>
-      task_def_path: ".aws/ecs/task-definition-app-${{ needs.context.outputs.environment }}.json"
-      container_name: <container_name>
-      aws_role_to_assume: ${{ needs.context.outputs.aws_ecs_deploy_role }}
+      GIT_REF: ${{ github.ref }}
+      IMAGE_URI: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}
+      ENVIRONMENT: ${{ needs.context.outputs.environment }}
+      AWS_REGION: ${{ needs.context.outputs.aws_region }}
+      ECS_CLUSTER: ${{ needs.context.outputs.aws_ecs_cluster }}
+      ECS_SERVICE: <ecs_service>
+      TASK_DEF_PATH: ".aws/ecs/task-definition-app-${{ needs.context.outputs.environment }}.json"
+      CONTAINER_NAME: <container_name>
+      AWS_ROLE_TO_ASSUME: ${{ needs.context.outputs.aws_ecs_deploy_role }}
 
   notify:
     name: Notify

--- a/workflow-examples/rollback/docker/rollback.yml
+++ b/workflow-examples/rollback/docker/rollback.yml
@@ -41,12 +41,12 @@ jobs:
   rollback:
     name: Rollback
     needs: [context]
-    uses: infinum/devops-pipelines/.github/workflows/rollback-ecs-service.yml@feature/add-ecs-rollback-workflow
+    uses: infinum/eightshift-deploy-actions-public/.github/workflows/rollback-ecs-service.yml@main
     with:
-      aws_region: ${{ needs.context.outputs.aws_region }}
-      aws_role_to_assume: ${{ needs.context.outputs.aws_ecs_deploy_role }}
-      ecs_cluster: ${{ needs.context.outputs.aws_ecs_cluster }}
-      ecs_service: <ecs_service>
+      AWS_REGION: ${{ needs.context.outputs.aws_region }}
+      AWS_ROLE_TO_ASSUME: ${{ needs.context.outputs.aws_ecs_deploy_role }}
+      ECS_CLUSTER: ${{ needs.context.outputs.aws_ecs_cluster }}
+      ECS_SERVICE: <ecs_service>
 
   notify:
     name: Notify


### PR DESCRIPTION
# Description

Removes the dependency on `infinum/devops-pipelines` for ECS deployments by bringing the `deploy-ecs-task-definition` workflow in-house.

### Added

- Added `.github/workflows/deploy-ecs-task-definition.yml` — reusable workflow for deploying a Docker image to an ECS service via task definition update

### Changed

- Updated all three docker workflow examples to call the new internal workflow instead of `infinum/devops-pipelines/.github/workflows/deploy-ecs-task-definition.yml@v3.0.0`

## What changed vs the devops-pipelines version

| | devops-pipelines | This repo |
|---|---|---|
| `actions/checkout` | v5 | v6 (Node.js 24) |
| `aws-actions/configure-aws-credentials` | v5 | v6 (Node.js 24) |
| `amazon-ecs-render-task-definition` | v1.8.0 | v1.8.4 |
| `amazon-ecs-deploy-task-definition` | v2 | v2 |
| Job name | "Update task definition and update service" | "Deploy to ECS service" |
| `timeout_minutes` | defined but unused | applied at job level |

Inputs and secrets are fully compatible — no changes needed in calling workflows beyond the `uses:` line.

## QA Guide

1. Trigger a Docker deploy workflow to staging
2. Verify the `deploy` job runs as "Deploy to ECS service"
3. Confirm the ECS task definition is updated and service stabilises
4. Check there are no Node.js 20 deprecation warnings in the Annotations

**Expected result:** Deployment completes successfully with no deprecation warnings, identical behavior to the devops-pipelines version.

# Screenshots / Videos

<!-- Add screenshots or screen recordings showing the changes in action. -->

# Productive ticket

N/A