### PR TITLE
Fix artifact download path in self-hosted runner deploy

### DIFF
--- a/.github/actions/ssh/server-deploy-self-hosted-runner/action.yml
+++ b/.github/actions/ssh/server-deploy-self-hosted-runner/action.yml
@@ -43,11 +43,12 @@ runs:
       shell: bash
       run: |
         echo "NOW=$(date +'%Y%m%d%H%M%S')" >> "$GITHUB_OUTPUT"
-      
+
     - name: Download a single artifact
       uses: actions/download-artifact@v8
       with:
         github-token: ${{ inputs.GITHUB_TOKEN }}
+        path: artifact
 
     - name: Add server SSH key
       uses: webfactory/ssh-agent@v0.10.0


### PR DESCRIPTION
## Summary
- Adds explicit `path: artifact` to `actions/download-artifact@v8` in the self-hosted runner deploy action to prevent artifact mismatch after deploy

## Test plan
- [ ] Run a deploy workflow using the self-hosted runner action and verify the artifact is downloaded to the correct path
- [ ] Confirm the deployed files match the expected build output