### PR TITLE
Remove USE_NODE input and reorder setup steps in theme/plugin actions

### DIFF
--- a/.github/actions/lint/assets/action.yml
+++ b/.github/actions/lint/assets/action.yml
@@ -1,19 +1,15 @@
 name: Lint assets - JS, CSS
-description: 'Lint assets - JS, CSS'
+description: "Lint assets - JS, CSS"
 
 inputs:
   NODE_VERSION:
     type: string
-    description: 'Node.js version to use. Available options are 14, 16, latest etc. Default is latest.'
+    description: "Node.js version to use. Available options are 14, 16, latest etc. Default is latest."
     required: true
   PROJECT_PATH:
     type: string
-    description: 'Path to the project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>'
+    description: "Path to the project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>"
     required: true
-  USE_BUN:
-    type: string
-    description: "If true, bun is used instead of npm for running scripts"
-    default: false
   USE_CHECKOUT:
     type: string
     description: "If true, checkout is used to install dependencies"
@@ -26,63 +22,24 @@ runs:
       if: inputs.USE_CHECKOUT == 'true'
       uses: actions/checkout@v6
 
-    - name: Set Node.js version - ${{ inputs.NODE_VERSION }}
-      if: inputs.USE_BUN == 'false'
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache: npm
-        cache-dependency-path: ${{ inputs.PROJECT_PATH }}/package-lock.json
-
-    - name: Set Node.js version - ${{ inputs.NODE_VERSION }}
-      if: inputs.USE_BUN == 'true'
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache-dependency-path: ${{ inputs.PROJECT_PATH }}/bun.lock
-
     - name: Install Bun
-      if: inputs.USE_BUN == 'true'
       uses: oven-sh/setup-bun@v2
       with:
         bun-version: latest
 
-    - name: Install assets packages with npm
-      working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_BUN == 'false'
-      shell: bash
-      run: |
-        npm ci --no-progress --no-audit --ignore-scripts
-        npm run build
-
     - name: Install assets packages with bun
       working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_BUN == 'true'
       shell: bash
       run: |
         bun install --ignore-scripts --frozen-lockfile
         bun run build
 
-    - name: Run linter - JS with npm
-      if: inputs.USE_BUN == 'false'
-      working-directory: ${{ inputs.PROJECT_PATH }}
-      shell: bash
-      run: npm run lintJs
-
-    - name: Run linters - CSS with npm
-      if: inputs.USE_BUN == 'false'
-      working-directory: ${{ inputs.PROJECT_PATH }}
-      shell: bash
-      run: npm run lintStyle
-
     - name: Run linter - JS with bun
-      if: inputs.USE_BUN == 'true'
       working-directory: ${{ inputs.PROJECT_PATH }}
       shell: bash
       run: bun run lintJs
 
     - name: Run linters - CSS with bun
-      if: inputs.USE_BUN == 'true'
       working-directory: ${{ inputs.PROJECT_PATH }}
       shell: bash
       run: bun run lintStyle

--- a/.github/actions/setup/theme-from-submodule-legacy/action.yml
+++ b/.github/actions/setup/theme-from-submodule-legacy/action.yml
@@ -1,31 +1,27 @@
 name: Install theme/plugin from submodule
-description: 'Install theme/plugin from submodule'
+description: "Install theme/plugin from submodule"
 
 inputs:
   NODE_VERSION:
     type: string
-    description: 'Node.js version to use. Available options are 14, 16, latest etc. Default is latest.'
-    default: 'latest'
+    description: "Node.js version to use. Available options are 14, 16, latest etc. Default is latest."
+    default: "latest"
   ROOT_PATH:
     type: string
-    description: 'Path to the root of the repository. Usually $GITHUB_WORKSPACE'
+    description: "Path to the root of the repository. Usually $GITHUB_WORKSPACE"
     required: true
   PROJECT_PATH:
     type: string
-    description: 'Path to the project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>'
+    description: "Path to the project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>"
     required: true
   SUBMODULE_PATH:
     type: string
-    description: 'Path to the root submodule folder from the root of the repository. Usually wordpress-infinum-web-redesign'
+    description: "Path to the root submodule folder from the root of the repository. Usually wordpress-infinum-web-redesign"
     required: true
   SUBMODULE_PROJECT_PATH:
     type: string
-    description: 'Path to the submodule project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>'
+    description: "Path to the submodule project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>"
     required: true
-  USE_BUN:
-    type: string
-    description: "If true, bun is used instead of npm for running scripts"
-    default: "false"
   PHP_VERSION:
     type: string
     description: "PHP version to use. Available options are 8.2, 8.3, 8.4, etc."
@@ -42,23 +38,7 @@ runs:
         cp -r ${{ inputs.ROOT_PATH }}/${{ inputs.SUBMODULE_PATH }}/${{ inputs.SUBMODULE_PROJECT_PATH }}/. ${{ inputs.ROOT_PATH }}/${{ inputs.PROJECT_PATH }}
         rm -rf ${{ inputs.ROOT_PATH }}/${{ inputs.SUBMODULE_PATH }}
 
-    - name: Install Node.js
-      if: inputs.USE_BUN == 'false'
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache: npm
-        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/package-lock.json"
-
-    - name: Install Node.js
-      if: inputs.USE_BUN == 'true'
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/bun.lock"
-
     - name: Install Bun
-      if: inputs.USE_BUN == 'true'
       uses: oven-sh/setup-bun@v2
       with:
         bun-version: latest
@@ -76,17 +56,8 @@ runs:
         composer-options: "--no-dev"
         working-directory: ${{ inputs.PROJECT_PATH }}
 
-    - name: Install assets packages with npm
-      if: inputs.USE_BUN == 'false'
-      working-directory: ${{ inputs.PROJECT_PATH }}
-      shell: bash
-      run: |
-        npm ci --no-progress --omit=dev --no-audit --ignore-scripts
-        npm run build
-
     - name: Install assets packages with bun
       working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_BUN == 'true'
       shell: bash
       run: |
         bun install --ignore-scripts --frozen-lockfile --production

--- a/.github/actions/setup/theme-from-submodule/action.yml
+++ b/.github/actions/setup/theme-from-submodule/action.yml
@@ -1,5 +1,5 @@
 name: Install theme/plugin from submodule
-description: 'Install theme/plugin from submodule'
+description: "Install theme/plugin from submodule"
 
 inputs:
   NODE_VERSION:
@@ -22,10 +22,6 @@ inputs:
     type: string
     description: "Path to the submodule project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>"
     required: true
-  USE_BUN:
-    type: string
-    description: "If true, bun is used instead of npm for running scripts"
-    default: "false"
   PHP_VERSION:
     type: string
     description: "PHP version to use. Available options are 8.2, 8.3, 8.4, etc."
@@ -42,23 +38,7 @@ runs:
         cp -r ${{ inputs.ROOT_PATH }}/${{ inputs.SUBMODULE_PATH }}/${{ inputs.SUBMODULE_PROJECT_PATH }}/. ${{ inputs.ROOT_PATH }}/${{ inputs.PROJECT_PATH }}
         rm -rf ${{ inputs.ROOT_PATH }}/${{ inputs.SUBMODULE_PATH }}
 
-    - name: Install Node.js
-      if: inputs.USE_BUN == 'false'
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache: npm
-        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/package-lock.json"
-
-    - name: Install Node.js
-      if: inputs.USE_BUN == 'true'
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/bun.lock"
-
     - name: Install Bun
-      if: inputs.USE_BUN == 'true'
       uses: oven-sh/setup-bun@v2
       with:
         bun-version: latest
@@ -76,17 +56,8 @@ runs:
         composer-options: "--no-dev"
         working-directory: ${{ inputs.PROJECT_PATH }}
 
-    - name: Install assets packages with npm
-      if: inputs.USE_BUN == 'false'
-      working-directory: ${{ inputs.PROJECT_PATH }}
-      shell: bash
-      run: |
-        npm ci --no-progress --omit=dev --no-audit --ignore-scripts
-        npm run build
-
     - name: Install assets packages with bun
       working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_BUN == 'true'
       shell: bash
       run: |
         bun install --ignore-scripts --frozen-lockfile --production

--- a/.github/actions/setup/theme-or-plugin-legacy/action.yml
+++ b/.github/actions/setup/theme-or-plugin-legacy/action.yml
@@ -10,10 +10,6 @@ inputs:
     type: string
     description: "Path to the project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>"
     required: true
-  USE_BUN:
-    type: string
-    description: "If true, bun is used instead of npm for running scripts"
-    default: "false"
   PHP_VERSION:
     type: string
     description: "PHP version to use. Available options are 8.2, 8.3, 8.4, etc."
@@ -37,41 +33,16 @@ runs:
         working-directory: ${{ inputs.PROJECT_PATH }}
 
     - name: Install Bun
-      if: inputs.USE_BUN == 'true'
       uses: oven-sh/setup-bun@v2
       with:
         bun-version: latest
 
-    - name: Install Node.js
-      uses: actions/setup-node@v6
-      if: inputs.USE_BUN == 'true'
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/bun.lock"
-
     - name: Install assets packages with bun
       working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_BUN == 'true'
       shell: bash
       run: |
         bun install --ignore-scripts --frozen-lockfile --production
         bun run build
-
-    - name: Install Node.js
-      uses: actions/setup-node@v6
-      if: inputs.USE_BUN == 'false'
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache: npm
-        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/package-lock.json"
-
-    - name: Install assets packages with npm
-      working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_BUN == 'false'
-      shell: bash
-      run: |
-        npm ci --no-progress --omit=dev --no-audit --ignore-scripts
-        npm run build
 
     - name: Post install cleanup - theme or plugin
       uses: infinum/eightshift-deploy-actions-public/.github/actions/cleanup/project@main

--- a/.github/actions/setup/theme-or-plugin-legacy/action.yml
+++ b/.github/actions/setup/theme-or-plugin-legacy/action.yml
@@ -1,5 +1,5 @@
 name: Install theme/plugin
-description: 'Install theme/plugin'
+description: "Install theme/plugin"
 
 inputs:
   NODE_VERSION:
@@ -10,10 +10,6 @@ inputs:
     type: string
     description: "Path to the project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>"
     required: true
-  USE_NODE:
-    type: string
-    description: "Set to default if you don't have node_modules folder in your project."
-    default: "true"
   USE_BUN:
     type: string
     description: "If true, bun is used instead of npm for running scripts"
@@ -27,27 +23,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install Node.js
-      uses: actions/setup-node@v6
-      if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'false'
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache: npm
-        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/package-lock.json"
-
-    - name: Install Node.js
-      uses: actions/setup-node@v6
-      if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'true'
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/bun.lock"
-
-    - name: Install Bun
-      if: inputs.USE_BUN == 'true'
-      uses: oven-sh/setup-bun@v2
-      with:
-        bun-version: latest
-
     - name: PHP setup
       uses: shivammathur/setup-php@v2
       with:
@@ -61,21 +36,42 @@ runs:
         composer-options: "--no-dev"
         working-directory: ${{ inputs.PROJECT_PATH }}
 
-    - name: Install assets packages with npm
-      working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'false'
-      shell: bash
-      run: |
-        npm ci --no-progress --omit=dev --no-audit --ignore-scripts
-        npm run build
+    - name: Install Bun
+      if: inputs.USE_BUN == 'true'
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
+
+    - name: Install Node.js
+      uses: actions/setup-node@v6
+      if: inputs.USE_BUN == 'true'
+      with:
+        node-version: ${{ inputs.NODE_VERSION }}
+        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/bun.lock"
 
     - name: Install assets packages with bun
       working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'true'
+      if: inputs.USE_BUN == 'true'
       shell: bash
       run: |
         bun install --ignore-scripts --frozen-lockfile --production
         bun run build
+
+    - name: Install Node.js
+      uses: actions/setup-node@v6
+      if: inputs.USE_BUN == 'false'
+      with:
+        node-version: ${{ inputs.NODE_VERSION }}
+        cache: npm
+        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/package-lock.json"
+
+    - name: Install assets packages with npm
+      working-directory: ${{ inputs.PROJECT_PATH }}
+      if: inputs.USE_BUN == 'false'
+      shell: bash
+      run: |
+        npm ci --no-progress --omit=dev --no-audit --ignore-scripts
+        npm run build
 
     - name: Post install cleanup - theme or plugin
       uses: infinum/eightshift-deploy-actions-public/.github/actions/cleanup/project@main

--- a/.github/actions/setup/theme-or-plugin/action.yml
+++ b/.github/actions/setup/theme-or-plugin/action.yml
@@ -10,10 +10,6 @@ inputs:
     type: string
     description: "Path to the project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>"
     required: true
-  USE_BUN:
-    type: string
-    description: "If true, bun is used instead of npm for running scripts"
-    default: "true"
   BUILD_SOURCEMAPS:
     type: string
     description: "If true, run a second build with sourcemaps enabled (output goes to public-sourcemaps/)"
@@ -41,14 +37,12 @@ runs:
         working-directory: ${{ inputs.PROJECT_PATH }}
 
     - name: Install Bun
-      if: inputs.USE_BUN == 'true'
       uses: oven-sh/setup-bun@v2
       with:
         bun-version: latest
 
     - name: Install assets packages with bun
       working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_BUN == 'true'
       shell: bash
       run: |
         bun install --ignore-scripts --frozen-lockfile --production
@@ -56,28 +50,6 @@ runs:
 
     - name: Build assets with sourcemaps (bun)
       working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_BUN == 'true' && inputs.BUILD_SOURCEMAPS == 'true'
+      if: inputs.BUILD_SOURCEMAPS == 'true'
       shell: bash
       run: bun run build:sourcemaps
-
-    - name: Install Node.js
-      uses: actions/setup-node@v6
-      if: inputs.USE_BUN == 'false'
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache: npm
-        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/package-lock.json"
-
-    - name: Install assets packages with npm
-      working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_BUN == 'false'
-      shell: bash
-      run: |
-        npm ci --no-progress --omit=dev --no-audit --ignore-scripts
-        npm run build
-
-    - name: Build assets with sourcemaps (npm)
-      working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_BUN == 'false' && inputs.BUILD_SOURCEMAPS == 'true'
-      shell: bash
-      run: npm run build:sourcemaps

--- a/.github/actions/setup/theme-or-plugin/action.yml
+++ b/.github/actions/setup/theme-or-plugin/action.yml
@@ -1,5 +1,5 @@
 name: Install theme/plugin
-description: 'Install theme/plugin'
+description: "Install theme/plugin"
 
 inputs:
   NODE_VERSION:
@@ -10,13 +10,13 @@ inputs:
     type: string
     description: "Path to the project folder from the root of the repository. Usually wp-content/themes/<theme_name> or wp-content/plugins/<plugin_name>"
     required: true
-  USE_NODE:
-    type: string
-    description: "Set to default if you don't have node_modules folder in your project."
-    default: "true"
   USE_BUN:
     type: string
     description: "If true, bun is used instead of npm for running scripts"
+    default: "true"
+  BUILD_SOURCEMAPS:
+    type: string
+    description: "If true, run a second build with sourcemaps enabled (output goes to public-sourcemaps/)"
     default: "false"
   PHP_VERSION:
     type: string
@@ -27,27 +27,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install Node.js
-      uses: actions/setup-node@v6
-      if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'false'
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache: npm
-        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/package-lock.json"
-
-    - name: Install Node.js
-      uses: actions/setup-node@v6
-      if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'true'
-      with:
-        node-version: ${{ inputs.NODE_VERSION }}
-        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/bun.lock"
-
-    - name: Install Bun
-      if: inputs.USE_BUN == 'true'
-      uses: oven-sh/setup-bun@v2
-      with:
-        bun-version: latest
-
     - name: PHP setup
       uses: shivammathur/setup-php@v2
       with:
@@ -61,18 +40,44 @@ runs:
         composer-options: "--no-dev"
         working-directory: ${{ inputs.PROJECT_PATH }}
 
+    - name: Install Bun
+      if: inputs.USE_BUN == 'true'
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
+
+    - name: Install assets packages with bun
+      working-directory: ${{ inputs.PROJECT_PATH }}
+      if: inputs.USE_BUN == 'true'
+      shell: bash
+      run: |
+        bun install --ignore-scripts --frozen-lockfile --production
+        bun run build
+
+    - name: Build assets with sourcemaps (bun)
+      working-directory: ${{ inputs.PROJECT_PATH }}
+      if: inputs.USE_BUN == 'true' && inputs.BUILD_SOURCEMAPS == 'true'
+      shell: bash
+      run: bun run build:sourcemaps
+
+    - name: Install Node.js
+      uses: actions/setup-node@v6
+      if: inputs.USE_BUN == 'false'
+      with:
+        node-version: ${{ inputs.NODE_VERSION }}
+        cache: npm
+        cache-dependency-path: "${{ inputs.PROJECT_PATH }}/package-lock.json"
+
     - name: Install assets packages with npm
       working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'false'
+      if: inputs.USE_BUN == 'false'
       shell: bash
       run: |
         npm ci --no-progress --omit=dev --no-audit --ignore-scripts
         npm run build
 
-    - name: Install assets packages with bun
+    - name: Build assets with sourcemaps (npm)
       working-directory: ${{ inputs.PROJECT_PATH }}
-      if: inputs.USE_NODE == 'true' && inputs.USE_BUN == 'true'
+      if: inputs.USE_BUN == 'false' && inputs.BUILD_SOURCEMAPS == 'true'
       shell: bash
-      run: |
-        bun install --ignore-scripts --frozen-lockfile --production
-        bun run build
+      run: npm run build:sourcemaps

--- a/workflow-examples/bundle-artifact/plugin.yml
+++ b/workflow-examples/bundle-artifact/plugin.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           PROJECT_PATH: "wp-content/plugins/<plugin_name>"
           NODE_VERSION: ${{ matrix.node }}
-          USE_BUN: true
 
       - name: Set cache
         uses: infinum/eightshift-deploy-actions-public/.github/actions/set/cache@main

--- a/workflow-examples/bundle-release/plugin.yml
+++ b/workflow-examples/bundle-release/plugin.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           PROJECT_PATH: "wp-content/plugins/<plugin_name>"
           NODE_VERSION: ${{ matrix.node }}
-          USE_BUN: true
 
       - name: Set cache
         uses: infinum/eightshift-deploy-actions-public/.github/actions/set/cache@main

--- a/workflow-examples/ci/plugin-project.yml
+++ b/workflow-examples/ci/plugin-project.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           NODE_VERSION: ${{ matrix.node }}
           PROJECT_PATH: wp-content/plugins/<plugin_name>
-          USE_BUN: true
 
   phpstan:
     name: PHP static code analysis using PHP - ${{ matrix.php }}

--- a/workflow-examples/ci/plugin.yml
+++ b/workflow-examples/ci/plugin.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           NODE_VERSION: ${{ matrix.node }}
           PROJECT_PATH: "."
-          USE_BUN: true
 
   phpstan:
     name: PHP static code analysis using PHP - ${{ matrix.php }}

--- a/workflow-examples/ci/theme-project.yml
+++ b/workflow-examples/ci/theme-project.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           NODE_VERSION: ${{ matrix.node }}
           PROJECT_PATH: wp-content/themes/<theme_name>
-          USE_BUN: true
 
   phpstan:
     name: PHP static code analysis using PHP - ${{ matrix.php }}

--- a/workflow-examples/deploy/docker/infinum-project-with-submodule-theme.yml
+++ b/workflow-examples/deploy/docker/infinum-project-with-submodule-theme.yml
@@ -76,7 +76,6 @@ jobs:
           PROJECT_PATH: wp-content/themes/<theme_name>
           SUBMODULE_PATH: <submodule_path>
           SUBMODULE_PROJECT_PATH: wp-content/themes/<theme_name>
-          USE_BUN: true
 
       - name: Update version number
         id: update-version

--- a/workflow-examples/deploy/docker/plugin-project.yml
+++ b/workflow-examples/deploy/docker/plugin-project.yml
@@ -67,7 +67,6 @@ jobs:
         uses: infinum/eightshift-deploy-actions-public/.github/actions/setup/theme-or-plugin@main
         with:
           PROJECT_PATH: wp-content/plugins/<plugin_name>
-          USE_BUN: true
 
       - name: Update version number
         id: update-version

--- a/workflow-examples/deploy/docker/theme-project.yml
+++ b/workflow-examples/deploy/docker/theme-project.yml
@@ -72,7 +72,6 @@ jobs:
         uses: infinum/eightshift-deploy-actions-public/.github/actions/setup/theme-or-plugin@main
         with:
           PROJECT_PATH: wp-content/themes/<theme_name>
-          USE_BUN: true
 
       - name: Update version number
         id: update-version

--- a/workflow-examples/deploy/ssh/infinum-project-with-submodule-theme.yml
+++ b/workflow-examples/deploy/ssh/infinum-project-with-submodule-theme.yml
@@ -76,7 +76,6 @@ jobs:
           PROJECT_PATH: wp-content/themes/<theme_name>
           SUBMODULE_PATH: <submodule_path>
           SUBMODULE_PROJECT_PATH: wp-content/themes/<theme_name>
-          USE_BUN: true
 
       - name: Set cache
         uses: infinum/eightshift-deploy-actions-public/.github/actions/set/cache@main
@@ -120,13 +119,12 @@ jobs:
           AWS_ROLE: ${{ secrets.AWS_ROLE }}
 
   notify:
-      name: Notify
-      runs-on: ubuntu-latest
-      environment: ${{ needs.context.outputs.environment }}
-      needs: [context, build-and-push]
-      steps:
-        - name: Notify
-          uses: infinum/eightshift-deploy-actions-public/.github/actions/slack-notification@main
-          with:
-            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
+    name: Notify
+    runs-on: ubuntu-latest
+    environment: ${{ needs.context.outputs.environment }}
+    needs: [context, build-and-push]
+    steps:
+      - name: Notify
+        uses: infinum/eightshift-deploy-actions-public/.github/actions/slack-notification@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/workflow-examples/deploy/ssh/plugin-project-self-hosted-runner.yml
+++ b/workflow-examples/deploy/ssh/plugin-project-self-hosted-runner.yml
@@ -73,7 +73,6 @@ jobs:
         uses: infinum/eightshift-deploy-actions-public/.github/actions/setup/theme-or-plugin@main
         with:
           PROJECT_PATH: wp-content/plugins/<plugin_name>
-          USE_BUN: true
 
       - name: Set cache
         uses: infinum/eightshift-deploy-actions-public/.github/actions/set/cache@main
@@ -116,11 +115,7 @@ jobs:
 
   deploy:
     name: Deploy to the server
-    runs-on:
-      [
-        self-hosted,
-        "${{ needs.context.outputs.environment }}",
-      ]
+    runs-on: [self-hosted, "${{ needs.context.outputs.environment }}"]
     environment: ${{ needs.context.outputs.environment }}
     needs: [context, build-and-push]
     cancel-timeout-minutes: 5
@@ -136,13 +131,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify:
-      name: Notify
-      runs-on: ubuntu-latest
-      environment: ${{ needs.context.outputs.environment }}
-      needs: [context, build-and-push, deploy]
-      steps:
-        - name: Notify
-          uses: infinum/eightshift-deploy-actions-public/.github/actions/slack-notification@main
-          with:
-            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
+    name: Notify
+    runs-on: ubuntu-latest
+    environment: ${{ needs.context.outputs.environment }}
+    needs: [context, build-and-push, deploy]
+    steps:
+      - name: Notify
+        uses: infinum/eightshift-deploy-actions-public/.github/actions/slack-notification@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/workflow-examples/deploy/ssh/plugin-project.yml
+++ b/workflow-examples/deploy/ssh/plugin-project.yml
@@ -73,7 +73,6 @@ jobs:
         uses: infinum/eightshift-deploy-actions-public/.github/actions/setup/theme-or-plugin@main
         with:
           PROJECT_PATH: wp-content/plugins/<plugin_name>
-          USE_BUN: true
 
       - name: Set cache
         uses: infinum/eightshift-deploy-actions-public/.github/actions/set/cache@main
@@ -117,13 +116,12 @@ jobs:
           AWS_ROLE: ${{ secrets.AWS_ROLE }}
 
   notify:
-      name: Notify
-      runs-on: ubuntu-latest
-      environment: ${{ needs.context.outputs.environment }}
-      needs: [context, build-and-push]
-      steps:
-        - name: Notify
-          uses: infinum/eightshift-deploy-actions-public/.github/actions/slack-notification@main
-          with:
-            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
+    name: Notify
+    runs-on: ubuntu-latest
+    environment: ${{ needs.context.outputs.environment }}
+    needs: [context, build-and-push]
+    steps:
+      - name: Notify
+        uses: infinum/eightshift-deploy-actions-public/.github/actions/slack-notification@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/workflow-examples/deploy/ssh/theme-project-self-hosted-runner.yml
+++ b/workflow-examples/deploy/ssh/theme-project-self-hosted-runner.yml
@@ -74,7 +74,6 @@ jobs:
         uses: infinum/eightshift-deploy-actions-public/.github/actions/setup/theme-or-plugin@main
         with:
           PROJECT_PATH: wp-content/themes/<theme_name>
-          USE_BUN: true
 
       - name: Set cache
         uses: infinum/eightshift-deploy-actions-public/.github/actions/set/cache@main
@@ -117,11 +116,7 @@ jobs:
 
   deploy:
     name: Deploy to the server
-    runs-on:
-      [
-        self-hosted,
-        "${{ needs.context.outputs.environment }}",
-      ]
+    runs-on: [self-hosted, "${{ needs.context.outputs.environment }}"]
     environment: ${{ needs.context.outputs.environment }}
     needs: [context, build-and-push]
     cancel-timeout-minutes: 5
@@ -137,12 +132,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify:
-      name: Notify
-      runs-on: ubuntu-latest
-      environment: ${{ needs.context.outputs.environment }}
-      needs: [context, build-and-push, deploy]
-      steps:
-        - name: Notify
-          uses: infinum/eightshift-deploy-actions-public/.github/actions/slack-notification@main
-          with:
-            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    name: Notify
+    runs-on: ubuntu-latest
+    environment: ${{ needs.context.outputs.environment }}
+    needs: [context, build-and-push, deploy]
+    steps:
+      - name: Notify
+        uses: infinum/eightshift-deploy-actions-public/.github/actions/slack-notification@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/workflow-examples/deploy/ssh/theme-project.yml
+++ b/workflow-examples/deploy/ssh/theme-project.yml
@@ -73,7 +73,6 @@ jobs:
         uses: infinum/eightshift-deploy-actions-public/.github/actions/setup/theme-or-plugin@main
         with:
           PROJECT_PATH: wp-content/themes/<theme_name>
-          USE_BUN: true
 
       - name: Set cache
         uses: infinum/eightshift-deploy-actions-public/.github/actions/set/cache@main
@@ -117,12 +116,12 @@ jobs:
           AWS_ROLE: ${{ secrets.AWS_ROLE }}
 
   notify:
-      name: Notify
-      runs-on: ubuntu-latest
-      environment: ${{ needs.context.outputs.environment }}
-      needs: [context, build-and-push]
-      steps:
-        - name: Notify
-          uses: infinum/eightshift-deploy-actions-public/.github/actions/slack-notification@main
-          with:
-            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    name: Notify
+    runs-on: ubuntu-latest
+    environment: ${{ needs.context.outputs.environment }}
+    needs: [context, build-and-push]
+    steps:
+      - name: Notify
+        uses: infinum/eightshift-deploy-actions-public/.github/actions/slack-notification@main
+        with:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
# Description

### Changed

- Updated step order across all setup actions: PHP/Composer setup first, then JS tooling
- Updated \`lint/assets\` action to use bun exclusively (removed \`USE_BUN\` toggle)
- Updated \`theme-from-submodule\` and \`theme-from-submodule-legacy\` actions to use bun exclusively
- Updated \`theme-or-plugin\` and \`theme-or-plugin-legacy\` actions to use bun exclusively
- Fixed YAML indentation in several SSH workflow examples (\`notify\` job, \`runs-on\` arrays)

### Removed

- Removed \`USE_NODE\` input from \`theme-or-plugin\` and \`theme-or-plugin-legacy\`
- Removed \`USE_BUN\` input from all setup and lint actions — bun is now the only supported toolchain
- Removed Node.js fallback paths (npm install/build steps) from all actions
- Removed \`USE_BUN: true\` from all workflow examples (no longer needed)

## QA Guide

1. Trigger a deploy using any setup action — PHP/Composer should run first, then bun installs and builds assets
2. Trigger a lint run using \`lint/assets\` — should install with bun and run \`lintJs\` + \`lintStyle\`
3. Confirm no \`USE_BUN\` or \`USE_NODE\` inputs are referenced anywhere in the workflow examples

**Expected result:** All actions use bun exclusively, PHP/Composer always runs before JS tooling